### PR TITLE
Merge the options parameter with the defaults in Headroom constructor

### DIFF
--- a/spec/Headroom.spec.js
+++ b/spec/Headroom.spec.js
@@ -31,6 +31,22 @@
         expect(hr.classes).toBe(Headroom.options.classes);
       });
 
+      it('merges the options arguments properly', function() {
+        var userOpts = {
+          tolerance : 30,
+          classes : {
+            initial : 'hr'
+          }
+        };
+
+        var hr = new Headroom(elem, userOpts);
+
+        expect(hr.tolerance).toBe(userOpts.tolerance);
+        expect(hr.offset).toBe(Headroom.options.offset);
+        expect(hr.classes.initial).toBe(userOpts.classes.initial);
+        expect(hr.classes.pinned).toBe(Headroom.options.classes.pinned);
+      });
+
     });
 
     describe('init', function() {

--- a/src/Headroom.js
+++ b/src/Headroom.js
@@ -1,3 +1,5 @@
+var extend;
+
 /**
  * UI enhancement for fixed headers.
  * Hides header when scrolling down
@@ -7,7 +9,7 @@
  * @param {Object} options options for the widget
  */
 function Headroom (elem, options) {
-  options = options || Headroom.options;
+  options = extend(options, Headroom.options);
 
   this.lastKnownScrollY = 0;
   this.elem             = elem;
@@ -111,4 +113,30 @@ Headroom.options = {
     unpinned : 'headroom--unpinned',
     initial : 'headroom'
   }
+};
+/**
+ * Helper function for extending objects
+ */
+extend = function (object /*, objectN ... */) {
+  if(arguments.length <= 0) {
+    throw new Error('Missing arguments in extend function');
+  }
+
+  var result = object || { },
+      key,
+      i;
+
+  for (i = 1; i < arguments.length; i++) {
+    var replacement = arguments[i] || { };
+
+    for (key in replacement) {
+      if(typeof result[key] === 'object') {
+        result[key] = extend(result[key], replacement[key]);
+      } else {
+        result[key] = result[key] || replacement[key];
+      }
+    }
+  }
+
+  return result;
 };


### PR DESCRIPTION
Rather than using just the parameter (leaving some fields empty if not supplied by the user), merge the two in order to ensure the fields are assigned.
