### PR TITLE
Fix: Header now only gets pinned/unpinned if it is unpinned/pinned

### DIFF
--- a/src/Headroom.js
+++ b/src/Headroom.js
@@ -55,16 +55,24 @@ Headroom.prototype = {
    * Unpins the header if it's currently pinned
    */
   unpin : function() {
-    this.elem.classList.add(this.classes.unpinned);
-    this.elem.classList.remove(this.classes.pinned);
+    if(this.elem.classList.contains(this.classes.pinned)) {
+      this.elem.classList.add(this.classes.unpinned);
+      this.elem.classList.remove(this.classes.pinned);
+    } else {
+      return;
+    }
   },
-
+  
   /**
    * Pins the header if it's currently unpinned
    */
   pin : function() {
-    this.elem.classList.remove(this.classes.unpinned);
-    this.elem.classList.add(this.classes.pinned);
+    if(this.elem.classList.contains(this.classes.unpinned)) {
+      this.elem.classList.remove(this.classes.unpinned);
+      this.elem.classList.add(this.classes.pinned);
+    } else {
+      return;
+    }
   },
 
   /**


### PR DESCRIPTION
When you load your document and slowly scroll down some 30px or so and scroll back up, the header gets pinned though it is already pinned/never got unpinned. Fixed this with an additional if-statement in the pin / unpin functions. Not sure if this is the right place or if it has to be fixed within the update function…?
