### PR TITLE
UX Tweaks

### DIFF
--- a/src/Headroom.js
+++ b/src/Headroom.js
@@ -85,19 +85,16 @@ Headroom.prototype = {
     var currentScrollY     = this.getScrollY(),
       toleranceExceeded    = Math.abs(currentScrollY-this.lastKnownScrollY) >= this.tolerance;
 
-    if(currentScrollY < 0) { // Ignore bouncy scrolling in OSX
+    if(currentScrollY < 0 || currentScrollY + window.innerHeight > document.body.scrollHeight) { // Ignore bouncy scrolling in OSX
       return;
     }
 
-    if(toleranceExceeded) {
-      if(currentScrollY > this.lastKnownScrollY && currentScrollY >= this.offset) {
-        this.unpin();
-      }
-      else if(currentScrollY < this.lastKnownScrollY) {
-        this.pin();
-      }
+    if(currentScrollY > this.lastKnownScrollY && currentScrollY >= this.offset && toleranceExceeded) {
+      this.unpin();
     }
-
+    else if((currentScrollY < this.lastKnownScrollY && toleranceExceeded) || currentScrollY <= this.offset) {
+      this.pin();
+    }
     this.lastKnownScrollY = currentScrollY;
   }
 };


### PR DESCRIPTION
Two little updates for some things that were nagging me:
- Previously, if the user scrolled slowly (below tolerance), it was easy to scroll to top without re-pinning (just scroll slowly with a larger offset to see). This additionally checks to see if user goes below offset, regardless of tolerance.
- For shallow pages, it was easy to trigger pinned status by "bouncing" against the bottom of the page (Mac Chrome/Safari). This adds to the same check that prevents this issue at the top of the page.

These are not well-tested across browsers, but hopefully they're of some use.
