### PR TITLE
Add detachEvent method for detaching scroll event

### DIFF
--- a/src/Headroom.js
+++ b/src/Headroom.js
@@ -82,8 +82,7 @@ Headroom.prototype = {
   destroy : function() {
     var classes = this.classes;
 
-    this.initialised = false;
-    window.removeEventListener('scroll', this.debouncer, false);
+    this.detachEvent();
     this.elem.classList.remove(classes.unpinned, classes.pinned, classes.top, classes.initial);
   },
 
@@ -100,7 +99,16 @@ Headroom.prototype = {
       this.debouncer.handleEvent();
     }
   },
-  
+
+  /**
+   * Detaches the scroll event
+   * @private
+   */
+  detachEvent : function() {
+    window.removeEventListener('scroll', this.debouncer, false);
+    this.initialised = false;
+  },
+
   /**
    * Unpins the header if it's currently pinned
    */


### PR DESCRIPTION
While this seems like a simple code refactor. I'm in a circumstance where I need to be able to temporarily disable the headroom event handling while I programmatically animate the scroll view when the user clicks a link.

Refactoring this allows me to use the headroom.detachEvent() and headroom.attachEvent() method as needed. 

I realize the attachEvent() is marked as @private, so if there is a better implementation you can think of, that would be great too. 
