### PR TITLE
add missing step to AngularJS usage instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@ $("#header").headroom();
 <p>Note: Zepto's additional <a href="https://github.com/madrobby/zepto#zepto-modules" title="https://github.com/madrobby/zepto#zepto-modules">data module</a> is required for compatibility.</p>
 
 <h3>With AngularJS</h3>
-<p>Include the <code>headroom.js</code> and <code>angular.headroom.js</code> scripts in your page, and then:</p>
+<p>Include the <code>headroom.js</code> and <code>angular.headroom.js</code> scripts in your page and require the <code>headroom</code> module in your AngularJS application module. Then:</p>
 <pre class="language-markup"><code>&lt;header headroom&gt;&lt;/header&gt;
 &lt;!-- or --&gt;
 &lt;headroom&gt;&lt;/headroom&gt;


### PR DESCRIPTION
Before the Angular directive can be used, the `headroom` module must be required in the Angular app. I think it's worth mentioning this on the page.
