### PR TITLE
Document headroom module inclusion for AngularJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,15 @@ Note: Zepto's additional [data module](https://github.com/madrobby/zepto#zepto-m
 
 ### With AngularJS
 
-Include the `headroom.js` and `angular.headroom.js` scripts in your page, and then:
+Include the `headroom.js` and `angular.headroom.js` scripts in your page, and include the Headroom module
+```javascript
+angular.module('app', [
+// your requires
+'headroom'
+]);
+```
+
+And then use the directive in your markup:
 
 ```html
 <header headroom></header>


### PR DESCRIPTION
The angularjs documentation was not entirely accurate - the headroom directive is included under the headroom module, thus, one must include that in the Angularjs app for it to work. 

Clarified that in the documentation.