### PR TITLE
Refactor and fixes to Angular Directive

### DIFF
--- a/src/angular.headroom.js
+++ b/src/angular.headroom.js
@@ -1,37 +1,37 @@
-(function(angular) {
-
-  if(!angular) {
-    return;
-  }
-
-  ///////////////
-  // Directive //
-  ///////////////
-
-  angular.module('headroom', []).directive('headroom', function() {
+(function (angular, Headroom) {
+  
+  function headroom($document, HeadroomService) {
     return {
-      restrict: 'EA',
       scope: {
         tolerance: '=',
         offset: '=',
         classes: '=',
         scroller: '@'
       },
-      link: function(scope, element) {
+      link: function link($scope, $element) {
         var options = {};
-        angular.forEach(Headroom.options, function(value, key) {
-          options[key] = scope[key] || Headroom.options[key];
-        });
-        if (options.scroller) {
-          options.scroller = document.querySelector(options.scroller);
+        var opts = HeadroomService.options;
+        for (var prop in opts) {
+          options[prop] = $scope[prop] || opts[prop];
         }
-        var headroom = new Headroom(element[0], options);
-        headroom.init();
-        scope.$on('$destroy', function() {
-          headroom.destroy();
-        });
+        if (options.scroller && options.scroller.toString() !== '[object Window]') {
+          options.scroller = $document.querySelector(options.scroller);
+        }
+        var headroom = new HeadroomService($element[0], options).init();
+        $scope.$on('$destroy', headroom.destroy);
       }
     };
-  });
+  }
+  
+  headroom.$inject = ['$document', 'HeadroomService'];
 
-}(window.angular));
+  function HeadroomService() {
+    return Headroom;
+  }
+
+  angular
+    .module('headroom', [])
+    .directive('headroom', headroom)
+    .factory('HeadroomService', HeadroomService);
+  
+})(window.angular, window.Headroom);

--- a/src/angular.headroom.js
+++ b/src/angular.headroom.js
@@ -11,11 +11,11 @@
       link: function link($scope, $element) {
         var options = {};
         var opts = HeadroomService.options;
+        if (options.scroller) {
+          options.scroller = $document.querySelector(options.scroller);
+        }
         for (var prop in opts) {
           options[prop] = $scope[prop] || opts[prop];
-        }
-        if (options.scroller && options.scroller.toString() !== '[object Window]') {
-          options.scroller = $document.querySelector(options.scroller);
         }
         var headroom = new HeadroomService($element[0], options).init();
         $scope.$on('$destroy', headroom.destroy);


### PR DESCRIPTION
This PR restructures the Headroom Directive:

*  Uses a `.factory()` to return the global dependency and register within Angular DI system
* Allows `HeadroomService` to be dependency injected
* Annotated dependencies for the Directive to prevent non-build system minification errors (such as ngAnnotate)
* Use Angular's internal `$document` wrapper over `window.document` Object
* Fixes a bug with `if (options.scroller)` that causes `[object Window]` error
* Replaced `angular.forEach` with native Object loop
* Reduced `$destroy` callback function to just `headroom.destroy` argument

One thing we need to discuss is integration of the isolate scope properties (`scope: {}` etc):

* Right now these are two-way binding instructions to Angular using `=`, however this will not update the right properties currently inside the `headroom` instance. One way to achieve this is setting up `$scope.$watch` on each property and registering the correct callback and property setter to achieve desired results.
* Some unit tests can be added but for an integration this size and with such simplicity I'm going to say don't bother