### PR TITLE
Fixes for AngularJS directive refactor

### DIFF
--- a/src/angular.headroom.js
+++ b/src/angular.headroom.js
@@ -4,7 +4,7 @@
     return;
   }
   
-  function headroom($document, HeadroomService) {
+  function headroom(HeadroomService) {
     return {
       scope: {
         tolerance: '=',
@@ -12,14 +12,14 @@
         classes: '=',
         scroller: '@'
       },
-      link: function link($scope, $element) {
+      link: function ($scope, $element) {
         var options = {};
         var opts = HeadroomService.options;
-        if (options.scroller) {
-          options.scroller = $document.querySelector(options.scroller);
-        }
         for (var prop in opts) {
           options[prop] = $scope[prop] || opts[prop];
+        }
+        if ($scope.scroller) {
+          options.scroller = document.querySelector($scope.scroller);
         }
         var headroom = new HeadroomService($element[0], options).init();
         $scope.$on('$destroy', headroom.destroy);
@@ -27,7 +27,7 @@
     };
   }
   
-  headroom.$inject = ['$document', 'HeadroomService'];
+  headroom.$inject = ['HeadroomService'];
 
   function HeadroomService() {
     return Headroom;


### PR DESCRIPTION
https://github.com/WickyNilliams/headroom.js/pull/202 introduced a few issues:
- `options.scroller` value got overridden due to the wrong order;
- `$document` has no method querySelector;