### PR TITLE
use passive event listeners

### DIFF
--- a/src/Headroom.js
+++ b/src/Headroom.js
@@ -37,6 +37,43 @@ function extend (object /*, objectN ... */) {
 }
 
 /**
+ * Used to detect browser support for adding an event listener with options
+ * Credit: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
+ */
+var supportsCaptureOption = false;
+try {
+    var opts = Object.defineProperty({}, 'capture', {
+        get: function () {
+            supportsCaptureOption = true;
+        }
+    });
+    window.addEventListener("test", null, opts);
+} catch (e) { }
+
+
+/**
+ * Helper to add an event listener with an options object in supported browsers
+ */
+function addEventListenerWithOptions(target, type, handler, options) {
+    var optionsOrCapture = options;
+    if (!supportsCaptureOption) {
+        optionsOrCapture = options.capture;
+    }
+    target.addEventListener(type, handler, optionsOrCapture);
+}
+
+/**
+ * Helper to remove an event listener with an options object in supported browsers
+ */
+function removeEventListenerWithOptions(target, type, handler, options) {
+    var optionsOrCapture = options;
+    if (!supportsCaptureOption) {
+        optionsOrCapture = options.capture;
+    }
+    target.removeEventListener(type, handler, optionsOrCapture);
+}
+
+/**
  * Helper function for normalizing tolerance option to object format
  */
 function normalizeTolerance (t) {
@@ -97,7 +134,10 @@ Headroom.prototype = {
 
     this.initialised = false;
     this.elem.classList.remove(classes.unpinned, classes.pinned, classes.top, classes.notTop, classes.initial);
-    this.scroller.removeEventListener('scroll', this.debouncer, false);
+    removeEventListenerWithOptions(this.scroller, 'scroll', this.debouncer, {
+        capture: false,
+        passive: true
+    });
   },
 
   /**
@@ -108,7 +148,10 @@ Headroom.prototype = {
     if(!this.initialised){
       this.lastKnownScrollY = this.getScrollY();
       this.initialised = true;
-      this.scroller.addEventListener('scroll', this.debouncer, false);
+      addEventListenerWithOptions(this.scroller, 'scroll', this.debouncer, {
+          capture: false,
+          passive: true
+      });
 
       this.debouncer.handleEvent();
     }


### PR DESCRIPTION
Since headroom never needs to cancel the scroll event, it can take advantage of passive event listeners to improve scroll performance in supported browsers. You can learn more about passive event listeners on the Chromium blog:

http://blog.chromium.org/2016/05/new-apis-to-help-developers-improve.html
