### PR TITLE
Adding methods to freeze / unfreeze the current headroom's state.

### DIFF
--- a/src/Headroom.js
+++ b/src/Headroom.js
@@ -67,7 +67,7 @@ function Headroom (elem, options) {
   this.onNotTop         = options.onNotTop;
   this.onBottom         = options.onBottom;
   this.onNotBottom      = options.onNotBottom;
-  this.freezed          = false;
+  this.frozen           = false;
 }
 Headroom.prototype = {
   constructor : Headroom,
@@ -346,7 +346,7 @@ Headroom.prototype = {
       return;
     }
 
-    if (this.freezed === true) {
+    if (this.frozen === true) {
       this.lastKnownScrollY = currentScrollY;
       return;
     }
@@ -378,18 +378,16 @@ Headroom.prototype = {
    * Freezes the current state of the widget
    */
   freeze : function() {
-    this.freezed = true;
-
-    this.elem.classList.add(this.classes.freezed);
+    this.frozen = true;
+    this.elem.classList.add(this.classes.frozen);
   },
 
   /**
    * Re-enables the default behaviour of the widget
    */
   unfreeze : function() {
-    this.freezed = false;
-
-    this.elem.classList.remove(this.classes.freezed);
+    this.frozen = false;
+    this.elem.classList.remove(this.classes.frozen);
   },
 
 };
@@ -405,7 +403,7 @@ Headroom.options = {
   offset : 0,
   scroller: window,
   classes : {
-    freezed : 'headroom--freezed',
+    frozen : 'headroom--frozen',
     pinned : 'headroom--pinned',
     unpinned : 'headroom--unpinned',
     top : 'headroom--top',

--- a/src/Headroom.js
+++ b/src/Headroom.js
@@ -67,6 +67,7 @@ function Headroom (elem, options) {
   this.onNotTop         = options.onNotTop;
   this.onBottom         = options.onBottom;
   this.onNotBottom      = options.onNotBottom;
+  this.freezed          = false;
 }
 Headroom.prototype = {
   constructor : Headroom,
@@ -345,6 +346,11 @@ Headroom.prototype = {
       return;
     }
 
+    if (this.freezed === true) {
+      this.lastKnownScrollY = currentScrollY;
+      return;
+    }
+
     if (currentScrollY <= this.offset ) {
       this.top();
     } else {
@@ -366,7 +372,26 @@ Headroom.prototype = {
     }
 
     this.lastKnownScrollY = currentScrollY;
-  }
+  },
+
+  /**
+   * Freezes the current state of the widget
+   */
+  freeze : function() {
+    this.freezed = true;
+
+    this.elem.classList.add(this.classes.freezed);
+  },
+
+  /**
+   * Re-enables the default behaviour of the widget
+   */
+  unfreeze : function() {
+    this.freezed = false;
+
+    this.elem.classList.remove(this.classes.freezed);
+  },
+
 };
 /**
  * Default options
@@ -380,6 +405,7 @@ Headroom.options = {
   offset : 0,
   scroller: window,
   classes : {
+    freezed : 'headroom--freezed',
     pinned : 'headroom--pinned',
     unpinned : 'headroom--unpinned',
     top : 'headroom--top',


### PR DESCRIPTION
Inspired from another PR (https://github.com/WickyNilliams/headroom.js/pull/253), I've added methods to freeze and unfreeze the current headroom's state.

- `freeze` method: When called, this method will freeze the current headroom's state (pinned or unpinned). Headroom will not react to the user's scroll. If you wish to re-enable the headroom's default behaviour, you can call unfreeze method.

- `unfreeze` method: When called, this method will resume headroom's default behaviour. Headroom will pin or unpin when the user scrolls the page. By default, Headroom is not freezed and calling this method before freeze will do nothing.

There is also a new property - `frozen` - for the classes option:
```
{
  classes: {
    // ... other classes
    freezed : 'headroom--frozen'
  }
}
```

Usage:
```
var headroom  = new Headroom(myElement);
// initialise
headroom.init();

// freeze 
headroom.freeze();

// unfreeze
headroom.unfreeze();
```


Example:
https://codepen.io/andreivictor/pen/oymbLO
