### PR TITLE
fix incorrect calculation for "bottom" on non-window scrollers

### DIFF
--- a/cypress/fixtures/index.html
+++ b/cypress/fixtures/index.html
@@ -50,6 +50,12 @@
       main {
         max-width: 40em;
       }
+
+      .scroller {
+        background-color: rgba(0, 0, 0, 0.3);
+        height: 400px;
+        overflow-y: auto;
+      }
     </style>
   </head>
 
@@ -235,6 +241,52 @@ width: 300px;
 height: 80px;
 }
 </code></pre>
+      <div class="scroller">
+        <p>
+          <strong>Pellentesque habitant morbi tristique</strong> senectus et
+          netus et malesuada fames ac turpis egestas. Vestibulum tortor quam,
+          feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero
+          sit amet quam egestas semper.
+          <em>Aenean ultricies mi vitae est.</em> Mauris placerat eleifend leo.
+          Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat
+          wisi, condimentum sed, <code>commodo vitae</code>, ornare sit amet,
+          wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum
+          rutrum orci, sagittis tempus lacus enim ac dui.
+          <a href="#">Donec non enim</a> in turpis pulvinar facilisis. Ut felis.
+        </p>
+
+        <h2>Header Level 2</h2>
+
+        <ol>
+          <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li>
+          <li>Aliquam tincidunt mauris eu risus.</li>
+        </ol>
+
+        <blockquote>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus
+            magna. Cras in mi at felis aliquet congue. Ut a est eget ligula
+            molestie gravida. Curabitur massa. Donec eleifend, libero at
+            sagittis mollis, tellus est malesuada tellus, at luctus turpis elit
+            sit amet quam. Vivamus pretium ornare est.
+          </p>
+        </blockquote>
+
+        <h3>Header Level 3</h3>
+
+        <ul>
+          <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li>
+          <li>Aliquam tincidunt mauris eu risus.</li>
+        </ul>
+
+        <pre><code>
+#header h1 a {
+display: block;
+width: 300px;
+height: 80px;
+}
+</code></pre>
+      </div>
     </main>
   </body>
 </html>

--- a/cypress/integration/headroom.spec.js
+++ b/cypress/integration/headroom.spec.js
@@ -22,7 +22,6 @@ describe("Headroom", function() {
     cy.window().then(win => {
       win.hr.destroy();
     });
-
     classNames({
       headroom: false,
       "headroom--unpinned": false,
@@ -75,17 +74,40 @@ describe("Headroom", function() {
       "headroom--not-bottom": true
     });
 
-    cy.scrollTo("bottom");
-    classNames({
-      "headroom--unpinned": true,
-      "headroom--pinned": false,
+    cy.window()
+      .then(win => {
+        return {
+          scrollHeight: win.hr.getScrollerHeight(),
+          height: win.hr.getScrollerPhysicalHeight()
+        };
+      })
+      .then(({ height, scrollHeight }) => {
+        const scrollDistanceToBottom = scrollHeight - height;
 
-      "headroom--top": false,
-      "headroom--not-top": true,
+        cy.scrollTo(0, scrollDistanceToBottom - 1);
+        classNames({
+          "headroom--pinned": false,
+          "headroom--unpinned": true,
 
-      "headroom--bottom": true,
-      "headroom--not-bottom": false
-    });
+          "headroom--top": false,
+          "headroom--not-top": true,
+
+          "headroom--bottom": false,
+          "headroom--not-bottom": true
+        });
+
+        cy.scrollTo(0, scrollDistanceToBottom);
+        classNames({
+          "headroom--pinned": false,
+          "headroom--unpinned": true,
+
+          "headroom--top": false,
+          "headroom--not-top": true,
+
+          "headroom--bottom": true,
+          "headroom--not-bottom": false
+        });
+      });
   });
 
   it("handles tolerance correctly", () => {
@@ -141,5 +163,83 @@ describe("Headroom", function() {
       "headroom--unpinned": false,
       "headroom--pinned": true
     });
+  });
+
+  it("handles scrollers besides window", () => {
+    cy.get(".scroller").then(scroller => {
+      initialiseHeadroom({ scroller: scroller[0] });
+    });
+    classNames({ headroom: true });
+
+    cy.get(".scroller").scrollTo(0, 50);
+    classNames({
+      "headroom--pinned": false,
+      "headroom--unpinned": true,
+
+      "headroom--top": false,
+      "headroom--not-top": true,
+
+      "headroom--bottom": false,
+      "headroom--not-bottom": true
+    });
+
+    cy.get(".scroller").scrollTo(0, 25);
+    classNames({
+      "headroom--pinned": true,
+      "headroom--unpinned": false,
+
+      "headroom--top": false,
+      "headroom--not-top": true,
+
+      "headroom--bottom": false,
+      "headroom--not-bottom": true
+    });
+
+    cy.get(".scroller").scrollTo(0, 0);
+    classNames({
+      "headroom--pinned": true,
+      "headroom--unpinned": false,
+
+      "headroom--top": true,
+      "headroom--not-top": false,
+
+      "headroom--bottom": false,
+      "headroom--not-bottom": true
+    });
+
+    cy.window()
+      .then(win => {
+        return {
+          scrollHeight: win.hr.getScrollerHeight(),
+          height: win.hr.getScrollerPhysicalHeight()
+        };
+      })
+      .then(({ height, scrollHeight }) => {
+        const scrollDistanceToBottom = scrollHeight - height;
+
+        cy.get(".scroller").scrollTo(0, scrollDistanceToBottom - 1);
+        classNames({
+          "headroom--pinned": false,
+          "headroom--unpinned": true,
+
+          "headroom--top": false,
+          "headroom--not-top": true,
+
+          "headroom--bottom": false,
+          "headroom--not-bottom": true
+        });
+
+        cy.get(".scroller").scrollTo(0, scrollDistanceToBottom);
+        classNames({
+          "headroom--pinned": false,
+          "headroom--unpinned": true,
+
+          "headroom--top": false,
+          "headroom--not-top": true,
+
+          "headroom--bottom": true,
+          "headroom--not-bottom": false
+        });
+      });
   });
 });

--- a/src/Headroom.js
+++ b/src/Headroom.js
@@ -435,7 +435,10 @@ Headroom.prototype = {
       this.notTop();
     }
 
-    if (currentScrollY + this.getViewportHeight() >= this.getScrollerHeight()) {
+    if (
+      currentScrollY + this.getScrollerPhysicalHeight() >=
+      this.getScrollerHeight()
+    ) {
       this.bottom();
     } else {
       this.notBottom();


### PR DESCRIPTION
There was incorrect logic for calculating when at `bottom`. If your scroller was not `window`, the `bottom` class would be applied too early as the code didn't account for the possibility of other types of scroller.

This PR fixes the issue, and improves the test suite to cover this