### PR TITLE
remove async behaviour of init. fixes #338

### DIFF
--- a/cypress/integration/headroom.spec.js
+++ b/cypress/integration/headroom.spec.js
@@ -6,7 +6,6 @@ describe("Headroom", function() {
       win.hr = new win.Headroom(win.document.querySelector("header"), options);
       win.hr.init();
     });
-    cy.wait(200);
   };
 
   beforeEach(() => {
@@ -262,7 +261,6 @@ describe("Headroom", function() {
         bottom: false
       });
     });
-    cy.wait(20).then(() => {});
 
     cy.scrollTo(0, 0);
     cy.should(() => {

--- a/src/Headroom.js
+++ b/src/Headroom.js
@@ -34,19 +34,7 @@ Headroom.prototype = {
     if (Headroom.cutsTheMustard && !this.initialised) {
       this.addClass("initial");
       this.initialised = true;
-
-      // defer event registration to handle browser
-      // potentially restoring previous scroll position
-      setTimeout(
-        function(self) {
-          self.scrollTracker = trackScroll(
-            self.scroller,
-            self.update.bind(self)
-          );
-        },
-        100,
-        this
-      );
+      this.scrollTracker = trackScroll(this.scroller, this.update.bind(this));
     }
 
     return this;
@@ -57,9 +45,11 @@ Headroom.prototype = {
    * @public
    */
   destroy: function() {
-    this.initialised = false;
-    Object.keys(this.classes).forEach(this.removeClass, this);
-    this.scrollTracker.destroy();
+    if (this.initialised) {
+      this.initialised = false;
+      Object.keys(this.classes).forEach(this.removeClass, this);
+      this.scrollTracker.destroy();
+    }
   },
 
   /**


### PR DESCRIPTION
Simplifies code and execution flow of initialisation. 

Secondary benefit: the test suite runs in around half the time, since we no longer have to wait for initialisation to complete