### PR TITLE
rename cutsTheMustard -> isSupported

### DIFF
--- a/src/Headroom.js
+++ b/src/Headroom.js
@@ -31,7 +31,7 @@ Headroom.prototype = {
    * @public
    */
   init: function() {
-    if (Headroom.cutsTheMustard && !this.initialised) {
+    if (!this.initialised) {
       this.addClass("initial");
       this.initialised = true;
 
@@ -224,6 +224,6 @@ Headroom.options = {
   }
 };
 
-Headroom.cutsTheMustard = isSupported();
+Headroom.isSupported = isSupported();
 
 export default Headroom;


### PR DESCRIPTION
Renaming `Headroom.cutsTheMustard` to `Headroom.isSupported` as discussed here: https://github.com/WickyNilliams/headroom.js/issues/350#issuecomment-539977025