### PR TITLE
add missing comma to example options

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@ headroom.init();
         // when not at bottom of scroll area
         notBottom : "headroom--not-bottom",
         // when frozen method has been called
-        frozen: "headroom--frozen"
+        frozen: "headroom--frozen",
         // multiple classes are also supported with a space-separated list
         pinned: "headroom--pinned foo bar"
     },


### PR DESCRIPTION
On the website, a comma is missing on the options example. Here's the fix. :)